### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ To configuring `.go-header.yml` linter you simply need to fill the next fields:
 
 ```yaml
 ---
-temaplte: # expects header template string.
-tempalte-path: # expects path to file with license header string. 
+template: # expects header template string.
+template-path: # expects path to file with license header string. 
 values: # expects `const` or `regexp` node with values where values is a map string to string.
   const:
     key1: value1 # const value just checks equality. Note `key1` should be used in template string as {{ key1 }} or {{ KEY1 }}.


### PR DESCRIPTION
There were a few typos in `README.md`. This change fixes them.